### PR TITLE
Revert "Update dependency topjohnwu/Magisk to v28"

### DIFF
--- a/rooted-ota.sh
+++ b/rooted-ota.sh
@@ -35,7 +35,7 @@ OTA_VERSION=${OTA_VERSION:-'latest'}
 # Breaking changes in magisk might need to be adapted in new avbroot version
 # Find latest magisk version here: https://github.com/topjohnwu/Magisk/releases, or:
 # curl --fail -sL -I -o /dev/null -w '%{url_effective}' https://github.com/topjohnwu/Magisk/releases/latest | sed 's/.*\/tag\///;'
-MAGISK_VERSION=${MAGISK_VERSION:-'v28.0'}
+MAGISK_VERSION=${MAGISK_VERSION:-'v27.0'}
 
 SKIP_CLEANUP=${SKIP_CLEANUP:-''}
 # Set asset released by this script to latest version, even when OTA_VERSION already exists for this device


### PR DESCRIPTION
Reverts schnatterer/rooted-graphene#23

```
.tmp/avbroot ota patch --output .tmp/oriole-2024100800-magisk-v28.0-680ce49.zip --input .tmp/oriole-ota_update-2024100800.zip --key-avb .tmp/avb.key --key-ota .tmp/ota.key --cert-ota .tmp/ota.crt --magisk .tmp/magisk-v28.0.apk --magisk-preinit-device metadata --pass-avb-env-var PASSPHRASE_AVB --pass-ota-env-var PASSPHRASE_OTA
  0.067s ERROR Failed to create Magisk boot image patcher
```