### PR TITLE
Discontinue some devices

### DIFF
--- a/.github/workflows/release-multiple.yaml
+++ b/.github/workflows/release-multiple.yaml
@@ -15,16 +15,16 @@ jobs:
         include:
           - device-id: caiman # Pixel 9 Pro
             magisk-preinit-device: sda10
-          - device-id: tokay # Pixel 9
-            magisk-preinit-device: sda10
-          - device-id: husky # Pixel 8 Pro
-            magisk-preinit-device: sda10
-          - device-id: shiba # Pixel 8
-            magisk-preinit-device: sda10
-          - device-id: bluejay # Pixel 6a
-            magisk-preinit-device: sda8
           - device-id: oriole # Pixel 6
             magisk-preinit-device: metadata
+#          - device-id: tokay # Pixel 9
+#            magisk-preinit-device: sda10
+#          - device-id: husky # Pixel 8 Pro
+#            magisk-preinit-device: sda10
+#          - device-id: shiba # Pixel 8
+#            magisk-preinit-device: sda10
+#          - device-id: bluejay # Pixel 6a
+#            magisk-preinit-device: sda8
           # - device-id: cheetah # Pixel Pro 7 
           #  magisk-preinit-device: persist # https://xdaforums.com/t/guide-to-lock-bootloader-while-using-rooted-otaos-magisk-root.4510295/page-5#post-88499289)
     uses: ./.github/workflows/release-single.yaml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ Allows for switching between magisk and rootless via OTA upgrades.
 
 ## Supported devices
 
-See [.github/workflows/release-multiple.yaml](.github/workflows/release-multiple.yaml)
+* Pixel 9 Pro
+* Pixel 6
+
+All other devices have been discontinued because the amount of GitHub actions minutes required for maintaining that 
+many devices exceed my spending limit.  
+
+If you have the [Magisk preinit string](#magisk-preinit-strings) (see [.github/workflows/release-multiple.yaml](.github/workflows/release-multiple.yaml)) for your device, you can easily fork this repo and build your own OTAs.
+
+
+![image](https://github.com/user-attachments/assets/11cf8fe9-b846-4979-8d7c-723408681354)
 
 ## Notable changelog
 
@@ -18,6 +27,10 @@ These are only changes related to rooted-graphene, not GrapheneOS itself.
 See [grapheneos.org/releases](https://grapheneos.org/releases) for that.
 
 ### Unreleased
+
+* Discontinued all devices but Pixel 6 and Pixel 9 Pro, because the amount of GitHub actions minutes required for 
+  maintaining that many devices exceed my spending limit.  
+  Please fork this repo and build your own OTAs.
 * Switch from custota signature file version 1 to 2 (introduced with [custota 5](https://github.com/chenxiaolong/Custota/blob/v5.0/CHANGELOG.md) in october 2024)
 * If you're using custoa magisk module version < 5, please upgrade.  
   Even better: Delete custota magisk module, because it is now packaged in the OTA.


### PR DESCRIPTION
All  devices except pix 9 pro and pix 6 have been discontinued because the amount of GitHub actions minutes required for maintaining that 
many devices exceed my spending limit.  

If you have the [Magisk preinit string](#magisk-preinit-strings) (see [.github/workflows/release-multiple.yaml](.github/workflows/release-multiple.yaml)) for your device, you can easily fork this repo and build your own OTAs.