### PR TITLE
Expose release creation

### DIFF
--- a/rooted-ota.sh
+++ b/rooted-ota.sh
@@ -386,6 +386,16 @@ function base642key() {
 }
 
 function releaseOta() {
+
+  createReleaseIfNecessary
+  
+  for flavor in "${!POTENTIAL_ASSETS[@]}"; do
+    local assetName="${POTENTIAL_ASSETS[$flavor]}"
+    uploadFile ".tmp/$assetName" "$assetName" "application/zip"
+  done
+}
+
+function createReleaseIfNecessary() {
   checkMandatoryVariable 'GITHUB_REPO' 'GITHUB_TOKEN'
 
   local response changelog src_repo current_commit 
@@ -438,11 +448,6 @@ function releaseOta() {
       exit 1
     fi
   fi
-
-  for flavor in "${!POTENTIAL_ASSETS[@]}"; do
-    local assetName="${POTENTIAL_ASSETS[$flavor]}"
-    uploadFile ".tmp/$assetName" "$assetName" "application/zip"
-  done
 }
 
 function uploadFile() {


### PR DESCRIPTION
This allows for creating the release without building the artifacts.

This way we should be able to avoid the concurrent problem and wasting resources on running all device builds.

Instead, we can just create the release and trigger building all artifacts on release.

As there still is the risk that some devices might be released later, we should keep the cron that checks all devices daily.
So this does not save resources in the end. But it decreases the risk of concurrency issues and it could speed up release discovery. The cron runs only 10s, so it could be run more often than the 10s x `number of devices` of release-multiple.

Validated with rooted-graphene/test@9d11179.