### PR TITLE
feat: add magisk-pixin flavor

### DIFF
--- a/.github/workflows/release-single.yaml
+++ b/.github/workflows/release-single.yaml
@@ -37,6 +37,11 @@ on:
         description: skip building rooted OTA
         type: boolean
         required: false
+      skip-magisk-pixin:
+        description: skip building OTA rooted with pixincreate's magisk fork
+        type: boolean
+        required: false
+        default: true
       upload-test-ota:
         description: Upload OTA to test folder
         required: false
@@ -83,12 +88,17 @@ jobs:
           echo "FORCE_BUILD=$(echo '${{ github.event.inputs.force-build || '' }}' | xargs)" >> $GITHUB_ENV
           echo "UPLOAD_TEST_OTA=$(echo '${{ github.event.inputs.upload-test-ota || '' }}' | xargs)" >> $GITHUB_ENV
           echo "SKIP_ROOTLESS=$(echo '${{ github.event.inputs.skip-rootless || '' }}' | xargs)" >> $GITHUB_ENV
+          # Note the explicit 'true' fallback: an empty value would enable the flavor,
+          # because the script only skips on the literal string "true"
+          echo "SKIP_MAGISK_PIXIN=$(echo '${{ github.event.inputs.skip-magisk-pixin || 'true' }}' | xargs)" >> $GITHUB_ENV
           echo "SKIP_RELEASE=$(echo '${{ github.event.inputs.skip-release || '' }}' | xargs)" >> $GITHUB_ENV
           
           if [[ "${{ github.event_name }}" == "push" ]]  || [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "Running on push: Simple build without release for device $DEVICE_ID"
             echo "FORCE_BUILD=true" >> $GITHUB_ENV
             echo "SKIP_RELEASE=true" >> $GITHUB_ENV
+            # Make sure the magisk-pixin flavor keeps building
+            echo "SKIP_MAGISK_PIXIN=false" >> $GITHUB_ENV
             echo "GITHUB_TOKEN=must-be-set-but-is-not-used" >> $GITHUB_ENV
           else
             echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/release-single.yaml
+++ b/.github/workflows/release-single.yaml
@@ -37,7 +37,7 @@ on:
         description: skip building rooted OTA
         type: boolean
         required: false
-      skip-magisk-pixin:
+      skip-pixincreate:
         description: skip building OTA rooted with pixincreate's magisk fork
         type: boolean
         required: false
@@ -90,15 +90,15 @@ jobs:
           echo "SKIP_ROOTLESS=$(echo '${{ github.event.inputs.skip-rootless || '' }}' | xargs)" >> $GITHUB_ENV
           # Note the explicit 'true' fallback: an empty value would enable the flavor,
           # because the script only skips on the literal string "true"
-          echo "SKIP_MAGISK_PIXIN=$(echo '${{ github.event.inputs.skip-magisk-pixin || 'true' }}' | xargs)" >> $GITHUB_ENV
+          echo "SKIP_PIXINCREATE=$(echo '${{ github.event.inputs.skip-pixincreate || 'true' }}' | xargs)" >> $GITHUB_ENV
           echo "SKIP_RELEASE=$(echo '${{ github.event.inputs.skip-release || '' }}' | xargs)" >> $GITHUB_ENV
           
           if [[ "${{ github.event_name }}" == "push" ]]  || [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "Running on push: Simple build without release for device $DEVICE_ID"
             echo "FORCE_BUILD=true" >> $GITHUB_ENV
             echo "SKIP_RELEASE=true" >> $GITHUB_ENV
-            # Make sure the magisk-pixin flavor keeps building
-            echo "SKIP_MAGISK_PIXIN=false" >> $GITHUB_ENV
+            # Make sure the pixincreate flavor keeps building
+            echo "SKIP_PIXINCREATE=false" >> $GITHUB_ENV
             echo "GITHUB_TOKEN=must-be-set-but-is-not-used" >> $GITHUB_ENV
           else
             echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/release-single.yaml
+++ b/.github/workflows/release-single.yaml
@@ -104,16 +104,32 @@ jobs:
             echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
           fi
       - run: sudo apt-get install -y jq curl git
+      - name: Use dummy keys and certs for PRs
+        # Neither vars nor secrets are exposed to external PRs. 
+        # We still want them to build so generating dummy secrets seems the pragmatic solution 
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+        env:
+          AVBROOT_PASS: ci-test-pass
+        run: |
+          DEBUG=1 SKIP_CLEANUP=true bash -c '. rooted-ota.sh && downloadAvBroot'
+          .tmp/avbroot key generate-key --pass-env-var AVBROOT_PASS -o avb.key
+          .tmp/avbroot key generate-key --pass-env-var AVBROOT_PASS -o ota.key
+          .tmp/avbroot key generate-cert --pass-env-var AVBROOT_PASS -k ota.key -o ota.crt
+          echo finished generating dummy keys
+          echo "PASSPHRASE_AVB=$AVBROOT_PASS" >> "$GITHUB_ENV"
+          echo "PASSPHRASE_OTA=$AVBROOT_PASS" >> "$GITHUB_ENV"
+
+          echo "KEY_AVB_BASE64=$(base64 -w0 avb.key)" >> "$GITHUB_ENV"
+          echo "KEY_OTA_BASE64=$(base64 -w0 ota.key)" >> "$GITHUB_ENV"
+          echo "CERT_OTA_BASE64=$(base64 -w0 ota.crt)" >> "$GITHUB_ENV"
       - name: release
         env:
           GITHUB_REPO: ${{ github.repository }}
-          # Load dev keys from vars. This is a random key, only used for signing throwaway dev builds. Not a leak!
-          # Loading the keys from secrets will make them inaccessible for untrusted PRs, leaving us with failed builds.
-          KEY_AVB_BASE64: ${{ vars.KEY_AVB_BASE64 }}
-          CERT_OTA_BASE64: ${{ vars.CERT_OTA_BASE64 }}
-          KEY_OTA_BASE64: ${{ vars.KEY_OTA_BASE64 }}
-          #PASSPHRASE_AVB: ${{ vars.PASSPHRASE_AVB }}
-          #PASSPHRASE_OTA: ${{ vars.PASSPHRASE_OTA }}
+          PASSPHRASE_AVB: ${{ secrets.PASSPHRASE_AVB || env.PASSPHRASE_AVB }}
+          PASSPHRASE_OTA: ${{ secrets.PASSPHRASE_OTA || env.PASSPHRASE_OTA }}
+          KEY_AVB_BASE64: ${{ secrets.KEY_AVB_BASE64 || env.KEY_AVB_BASE64 }}
+          KEY_OTA_BASE64: ${{ secrets.KEY_OTA_BASE64 || env.KEY_OTA_BASE64 }}
+          CERT_OTA_BASE64: ${{ secrets.CERT_OTA_BASE64 || env.CERT_OTA_BASE64 }}
         run: |
           if [[ $SKIP_RELEASE == 'true' ]]; then
             DEBUG=1 bash -c '. rooted-ota.sh && createRootedOta && createOtaServerData'

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,6 +15,7 @@ on:
       - .github/workflows/renovate.yaml
 jobs:
   renovate:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -367,6 +367,15 @@ Also, some parts of kernelsu seem to be closed source, which feels suspicious an
 Another alternative might be to use a version of magisk (like [the one maintained by pixincreate](https://github.com/pixincreate/Magisk)) that contains patches to make zygisk work.  
 This still has some limitations, like [certain modules checking for magisk's signature won't work](https://github.com/schnatterer/rooted-graphene/commit/da0cd817c2665798df46df1aeb7caef9d98b79d0#r141746606).
 
+This variant can be built as an additional `magisk-pixin` flavor, next to the regular `magisk` and `rootless` ones.  
+It is disabled by default, so it is never silently forced on existing users. Enable it by setting `SKIP_MAGISK_PIXIN=false`
+(or the `skip-magisk-pixin` input in `release-single.yaml`). It requires `MAGISK_PREINIT_DEVICE` to be set, just like the regular magisk flavor,
+and it reuses `MAGISK_VERSION`, since the fork uses the same tags as upstream magisk.
+
+The resulting OTAs are published as a separate flavor, so in Custota you would point to the `magisk-pixin` path of your OTA server, e.g.
+`https://rooted-graphene.github.io/ota/magisk-pixin`. As with the other flavors, you can switch between them via OTA updates.
+
+> ⚠️ By using this flavor you also have to trust the authors of that fork, in addition to everyone listed above.
 Another option [might be](https://github.com/schnatterer/rooted-graphene/pull/73#issuecomment-2666870886) Kitsune magisk.
 
 In general, using [magisk and especially zygisk with Graphene seems to have the risk of breaking things with every new release](https://github.com/chenxiaolong/avbroot/issues/213#issuecomment-1986637884).  

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ GrapheneOS over the air updates (OTAs) patched with Magisk allowing for AVB and 
 Can be upgraded over the air using [Custota](https://github.com/chenxiaolong/Custota) and its own OTA server.  
 Allows for switching between magisk and rootless via OTA upgrades.
 
-> ⚠️ OS and root work in general. However, zygisk does not (and [likely never will](https://github.com/topjohnwu/Magisk/pull/7606)) 
+> ⚠️ OS and root work in general. However, with upstream magisk zygisk does not (and [likely never will](https://github.com/topjohnwu/Magisk/pull/7606))
 > work, leading to magisk being easily discovered by other apps and lots of banking apps not working.  
- See [below](#using-other-rooting-mechanisms) for alternatives.
+> As an alternative we offer [pixincreate's magisk](https://github.com/pixincreate/Magisk) that contains patches to make zygisk work. Before using it please note that this way you add another party to your supply chain that basically gains root acces to your device.  
+ See [below](#using-other-rooting-mechanisms) for more details and the reason why kernelsu cannot be integrated easily with this project.
 
 ## Supported devices
 
@@ -367,13 +368,13 @@ Also, some parts of kernelsu seem to be closed source, which feels suspicious an
 Another alternative might be to use a version of magisk (like [the one maintained by pixincreate](https://github.com/pixincreate/Magisk)) that contains patches to make zygisk work.  
 This still has some limitations, like [certain modules checking for magisk's signature won't work](https://github.com/schnatterer/rooted-graphene/commit/da0cd817c2665798df46df1aeb7caef9d98b79d0#r141746606).
 
-This variant can be built as an additional `magisk-pixin` flavor, next to the regular `magisk` and `rootless` ones.  
-It is disabled by default, so it is never silently forced on existing users. Enable it by setting `SKIP_MAGISK_PIXIN=false`
-(or the `skip-magisk-pixin` input in `release-single.yaml`). It requires `MAGISK_PREINIT_DEVICE` to be set, just like the regular magisk flavor,
+This variant can be built as an additional `pixincreate` flavor, next to the regular `magisk` and `rootless` ones.  
+It is disabled by default, so it is never silently forced on existing users. Enable it by setting `SKIP_PIXINCREATE=false`
+(or the `skip-pixincreate` input in `release-single.yaml`). It requires `MAGISK_PREINIT_DEVICE` to be set, just like the regular magisk flavor,
 and it reuses `MAGISK_VERSION`, since the fork uses the same tags as upstream magisk.
 
-The resulting OTAs are published as a separate flavor, so in Custota you would point to the `magisk-pixin` path of your OTA server, e.g.
-`https://rooted-graphene.github.io/ota/magisk-pixin`. As with the other flavors, you can switch between them via OTA updates.
+The resulting OTAs are published as a separate flavor, so in Custota you would point to the `pixincreate` path of your OTA server, e.g.
+`https://rooted-graphene.github.io/ota/pixincreate`. As with the other flavors, you can switch between them via OTA updates.
 
 > ⚠️ By using this flavor you also have to trust the authors of that fork, in addition to everyone listed above.
 Another option [might be](https://github.com/schnatterer/rooted-graphene/pull/73#issuecomment-2666870886) Kitsune magisk.

--- a/rooted-ota.sh
+++ b/rooted-ota.sh
@@ -39,6 +39,14 @@ OTA_VERSION=${OTA_VERSION:-'latest'}
 DEFAULT_MAGISK_VERSION=v30.7
 MAGISK_VERSION=${MAGISK_VERSION:-${DEFAULT_MAGISK_VERSION}}
 
+# Additional flavor built with the pixincreate Magisk fork (zygisk patches for GrapheneOS)
+# https://github.com/pixincreate/Magisk
+# Enable by setting MAGISK_PIXIN=true (requires MAGISK_PREINIT_DEVICE to be set as well)
+MAGISK_PIXIN=${MAGISK_PIXIN:-'false'}
+# renovate: datasource=github-releases packageName=pixincreate/Magisk versioning=semver-coerced
+DEFAULT_MAGISK_PIXIN_VERSION=v30.7
+MAGISK_PIXIN_VERSION=${MAGISK_PIXIN_VERSION:-${DEFAULT_MAGISK_PIXIN_VERSION}}
+
 SKIP_CLEANUP=${SKIP_CLEANUP:-''}
 
 # For committing to GH pages in different repo, clone it to a different folder and set this var
@@ -147,6 +155,13 @@ function checkBuildNecessary() {
   else 
     printGreen "MAGISK_PREINIT_DEVICE not set for device, not creating magisk OTA"
   fi
+
+  if [[ "$MAGISK_PIXIN" == 'true' ]] && [[ -n "$MAGISK_PREINIT_DEVICE" ]]; then
+    # e.g. oriole-2023121200-magisk-pixin-v30.7-4647f74-dirty.zip
+    POTENTIAL_ASSETS['magisk-pixin']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-pixin-${MAGISK_PIXIN_VERSION}$(createAssetSuffix).zip"
+  elif [[ "$MAGISK_PIXIN" == 'true' ]]; then
+    printGreen "MAGISK_PREINIT_DEVICE not set for device, not creating magisk-pixin OTA"
+  fi
   
   if [[ "$SKIP_ROOTLESS" != 'true' ]]; then
     POTENTIAL_ASSETS['rootless']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-rootless$(createAssetSuffix).zip"
@@ -186,6 +201,10 @@ function checkBuildNecessary() {
       selectedAsset=$(echo "${response}" | jq -r --arg assetPrefix "${DEVICE_ID}-${OTA_VERSION}" \
         '.assets[] | select(.name | startswith($assetPrefix)) | .name' \
           | grep "${flavor}" || true)
+      # "magisk" is a substring of "magisk-pixin", so exclude pixin assets when checking the plain magisk flavor
+      if [[ "$flavor" == 'magisk' ]]; then
+        selectedAsset=$(echo "${selectedAsset}" | grep -v 'magisk-pixin' || true)
+      fi
   
       if [[ -n "${selectedAsset}" ]] && [[ "$FORCE_BUILD" != 'true' ]] && [[ "$UPLOAD_TEST_OTA" != 'true' ]]; then
         printGreen "Skipping build of asset name '$POTENTIAL_ASSET_NAME'. Because this flavor already is released with a different commit." \
@@ -238,6 +257,11 @@ function downloadAndroidDependencies() {
     curl --fail -sLo ".tmp/magisk-$MAGISK_VERSION.apk" "https://github.com/topjohnwu/Magisk/releases/download/$MAGISK_VERSION/Magisk-$MAGISK_VERSION.apk"
   fi
 
+  # pixincreate fork names its release asset "app-release.apk"
+  if ! ls ".tmp/magisk-pixin-$MAGISK_PIXIN_VERSION.apk" >/dev/null 2>&1 && [[ "${POTENTIAL_ASSETS['magisk-pixin']+isset}" ]]; then
+    curl --fail -sLo ".tmp/magisk-pixin-$MAGISK_PIXIN_VERSION.apk" "https://github.com/pixincreate/Magisk/releases/download/$MAGISK_PIXIN_VERSION/app-release.apk"
+  fi
+
   if ! ls ".tmp/$OTA_TARGET.zip" >/dev/null 2>&1; then
     curl --fail -sLo ".tmp/$OTA_TARGET.zip" "$OTA_URL"
   fi
@@ -248,6 +272,13 @@ function findLatestVersion() {
 
   if [[ "$MAGISK_VERSION" == 'latest' ]]; then
     MAGISK_VERSION=$(curl --fail -sL -I -o /dev/null -w '%{url_effective}' https://github.com/topjohnwu/Magisk/releases/latest | sed 's/.*\/tag\///;')
+  fi
+
+  if [[ "$MAGISK_PIXIN_VERSION" == 'latest' ]]; then
+    MAGISK_PIXIN_VERSION=$(curl --fail -sL -I -o /dev/null -w '%{url_effective}' https://github.com/pixincreate/Magisk/releases/latest | sed 's/.*\/tag\///;')
+  fi
+  if [[ "$MAGISK_PIXIN" == 'true' ]]; then
+    print "Magisk (pixincreate fork) version: $MAGISK_PIXIN_VERSION"
   fi
   print "Magisk version: $MAGISK_VERSION"
 
@@ -327,6 +358,10 @@ function patchOTAs() {
       args+=("--sign-cert-ota" "$CERT_OTA")
       if [[ "$flavor" == 'magisk' ]]; then
         args+=("--patch-arg=--magisk" "--patch-arg" ".tmp/magisk-$MAGISK_VERSION.apk")
+        args+=("--patch-arg=--magisk-preinit-device" "--patch-arg" "$MAGISK_PREINIT_DEVICE")
+      fi
+      if [[ "$flavor" == 'magisk-pixin' ]]; then
+        args+=("--patch-arg=--magisk" "--patch-arg" ".tmp/magisk-pixin-$MAGISK_PIXIN_VERSION.apk")
         args+=("--patch-arg=--magisk-preinit-device" "--patch-arg" "$MAGISK_PREINIT_DEVICE")
       fi
 

--- a/rooted-ota.sh
+++ b/rooted-ota.sh
@@ -28,6 +28,12 @@ GITHUB_REPO=${GITHUB_REPO:-''}
 MAGISK_PREINIT_DEVICE=${MAGISK_PREINIT_DEVICE:-}
 # Skip creation of rootless OTA by setting to "true"
 SKIP_ROOTLESS=${SKIP_ROOTLESS:-'false'}
+# In addition to upstream magisk, an OTA can be patched with pixincreate's magisk fork,
+# which contains patches that make zygisk work on GrapheneOS.
+# https://github.com/pixincreate/Magisk
+# Note that modules verifying magisk's signature won't work with this fork.
+# Enable by setting to "false".
+SKIP_MAGISK_PIXIN=${SKIP_MAGISK_PIXIN:-'true'}
 # https://grapheneos.org/releases#stable-channel
 OTA_VERSION=${OTA_VERSION:-'latest'}
 
@@ -38,14 +44,6 @@ OTA_VERSION=${OTA_VERSION:-'latest'}
 # renovate: datasource=github-releases packageName=topjohnwu/Magisk versioning=semver-coerced
 DEFAULT_MAGISK_VERSION=v30.7
 MAGISK_VERSION=${MAGISK_VERSION:-${DEFAULT_MAGISK_VERSION}}
-
-# Additional flavor built with the pixincreate Magisk fork (zygisk patches for GrapheneOS)
-# https://github.com/pixincreate/Magisk
-# Enable by setting MAGISK_PIXIN=true (requires MAGISK_PREINIT_DEVICE to be set as well)
-MAGISK_PIXIN=${MAGISK_PIXIN:-'false'}
-# renovate: datasource=github-releases packageName=pixincreate/Magisk versioning=semver-coerced
-DEFAULT_MAGISK_PIXIN_VERSION=v30.7
-MAGISK_PIXIN_VERSION=${MAGISK_PIXIN_VERSION:-${DEFAULT_MAGISK_PIXIN_VERSION}}
 
 SKIP_CLEANUP=${SKIP_CLEANUP:-''}
 
@@ -75,7 +73,7 @@ NO_COLOR=${NO_COLOR:-''}
 OTA_BASE_URL="https://releases.grapheneos.org"
 
 # renovate: datasource=github-releases packageName=chenxiaolong/avbroot versioning=semver
-AVB_ROOT_VERSION=3.31.0
+AVB_ROOT_VERSION=3.32.0
 # renovate: datasource=github-releases packageName=chenxiaolong/Custota versioning=semver-coerced
 CUSTOTA_VERSION=6.2
 # renovate: datasource=git-refs packageName=https://github.com/chenxiaolong/my-avbroot-setup currentValue=master
@@ -152,15 +150,15 @@ function checkBuildNecessary() {
   if [[ -n "$MAGISK_PREINIT_DEVICE" ]]; then 
     # e.g. oriole-2023121200-magisk-v26.4-4647f74-dirty.zip
     POTENTIAL_ASSETS['magisk']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-${MAGISK_VERSION}$(createAssetSuffix).zip"
+
+    if [[ "$SKIP_MAGISK_PIXIN" != 'true' ]]; then
+      # e.g. oriole-2023121200-magisk-pixin-v30.7-4647f74-dirty.zip
+      POTENTIAL_ASSETS['magisk-pixin']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-pixin-${MAGISK_VERSION}$(createAssetSuffix).zip"
+    else
+      printGreen "SKIP_MAGISK_PIXIN set, not creating magisk-pixin OTA"
+    fi
   else 
     printGreen "MAGISK_PREINIT_DEVICE not set for device, not creating magisk OTA"
-  fi
-
-  if [[ "$MAGISK_PIXIN" == 'true' ]] && [[ -n "$MAGISK_PREINIT_DEVICE" ]]; then
-    # e.g. oriole-2023121200-magisk-pixin-v30.7-4647f74-dirty.zip
-    POTENTIAL_ASSETS['magisk-pixin']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-pixin-${MAGISK_PIXIN_VERSION}$(createAssetSuffix).zip"
-  elif [[ "$MAGISK_PIXIN" == 'true' ]]; then
-    printGreen "MAGISK_PREINIT_DEVICE not set for device, not creating magisk-pixin OTA"
   fi
   
   if [[ "$SKIP_ROOTLESS" != 'true' ]]; then
@@ -201,7 +199,8 @@ function checkBuildNecessary() {
       selectedAsset=$(echo "${response}" | jq -r --arg assetPrefix "${DEVICE_ID}-${OTA_VERSION}" \
         '.assets[] | select(.name | startswith($assetPrefix)) | .name' \
           | grep "${flavor}" || true)
-      # "magisk" is a substring of "magisk-pixin", so exclude pixin assets when checking the plain magisk flavor
+      # "magisk" is a substring of "magisk-pixin". Without this, an existing magisk-pixin asset
+      # would make the plain magisk flavor be skipped.
       if [[ "$flavor" == 'magisk' ]]; then
         selectedAsset=$(echo "${selectedAsset}" | grep -v 'magisk-pixin' || true)
       fi
@@ -257,9 +256,9 @@ function downloadAndroidDependencies() {
     curl --fail -sLo ".tmp/magisk-$MAGISK_VERSION.apk" "https://github.com/topjohnwu/Magisk/releases/download/$MAGISK_VERSION/Magisk-$MAGISK_VERSION.apk"
   fi
 
-  # pixincreate fork names its release asset "app-release.apk"
-  if ! ls ".tmp/magisk-pixin-$MAGISK_PIXIN_VERSION.apk" >/dev/null 2>&1 && [[ "${POTENTIAL_ASSETS['magisk-pixin']+isset}" ]]; then
-    curl --fail -sLo ".tmp/magisk-pixin-$MAGISK_PIXIN_VERSION.apk" "https://github.com/pixincreate/Magisk/releases/download/$MAGISK_PIXIN_VERSION/app-release.apk"
+  # pixincreate's fork releases its APK as "app-release.apk" and uses the same tags as upstream magisk
+  if ! ls ".tmp/magisk-pixin-$MAGISK_VERSION.apk" >/dev/null 2>&1 && [[ "${POTENTIAL_ASSETS['magisk-pixin']+isset}" ]]; then
+    curl --fail -sLo ".tmp/magisk-pixin-$MAGISK_VERSION.apk" "https://github.com/pixincreate/Magisk/releases/download/$MAGISK_VERSION/app-release.apk"
   fi
 
   if ! ls ".tmp/$OTA_TARGET.zip" >/dev/null 2>&1; then
@@ -272,13 +271,6 @@ function findLatestVersion() {
 
   if [[ "$MAGISK_VERSION" == 'latest' ]]; then
     MAGISK_VERSION=$(curl --fail -sL -I -o /dev/null -w '%{url_effective}' https://github.com/topjohnwu/Magisk/releases/latest | sed 's/.*\/tag\///;')
-  fi
-
-  if [[ "$MAGISK_PIXIN_VERSION" == 'latest' ]]; then
-    MAGISK_PIXIN_VERSION=$(curl --fail -sL -I -o /dev/null -w '%{url_effective}' https://github.com/pixincreate/Magisk/releases/latest | sed 's/.*\/tag\///;')
-  fi
-  if [[ "$MAGISK_PIXIN" == 'true' ]]; then
-    print "Magisk (pixincreate fork) version: $MAGISK_PIXIN_VERSION"
   fi
   print "Magisk version: $MAGISK_VERSION"
 
@@ -361,7 +353,7 @@ function patchOTAs() {
         args+=("--patch-arg=--magisk-preinit-device" "--patch-arg" "$MAGISK_PREINIT_DEVICE")
       fi
       if [[ "$flavor" == 'magisk-pixin' ]]; then
-        args+=("--patch-arg=--magisk" "--patch-arg" ".tmp/magisk-pixin-$MAGISK_PIXIN_VERSION.apk")
+        args+=("--patch-arg=--magisk" "--patch-arg" ".tmp/magisk-pixin-$MAGISK_VERSION.apk")
         args+=("--patch-arg=--magisk-preinit-device" "--patch-arg" "$MAGISK_PREINIT_DEVICE")
       fi
 

--- a/rooted-ota.sh
+++ b/rooted-ota.sh
@@ -33,7 +33,7 @@ SKIP_ROOTLESS=${SKIP_ROOTLESS:-'false'}
 # https://github.com/pixincreate/Magisk
 # Note that modules verifying magisk's signature won't work with this fork.
 # Enable by setting to "false".
-SKIP_MAGISK_PIXIN=${SKIP_MAGISK_PIXIN:-'true'}
+SKIP_PIXINCREATE=${SKIP_PIXINCREATE:-'true'}
 # https://grapheneos.org/releases#stable-channel
 OTA_VERSION=${OTA_VERSION:-'latest'}
 
@@ -151,11 +151,11 @@ function checkBuildNecessary() {
     # e.g. oriole-2023121200-magisk-v26.4-4647f74-dirty.zip
     POTENTIAL_ASSETS['magisk']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-${MAGISK_VERSION}$(createAssetSuffix).zip"
 
-    if [[ "$SKIP_MAGISK_PIXIN" != 'true' ]]; then
-      # e.g. oriole-2023121200-magisk-pixin-v30.7-4647f74-dirty.zip
-      POTENTIAL_ASSETS['magisk-pixin']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-pixin-${MAGISK_VERSION}$(createAssetSuffix).zip"
+    if [[ "$SKIP_PIXINCREATE" != 'true' ]]; then
+      # e.g. oriole-2023121200-pixincreate-v30.7-4647f74-dirty.zip
+      POTENTIAL_ASSETS['pixincreate']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-pixincreate-${MAGISK_VERSION}$(createAssetSuffix).zip"
     else
-      printGreen "SKIP_MAGISK_PIXIN set, not creating magisk-pixin OTA"
+      printGreen "SKIP_PIXINCREATE set, not creating pixincreate OTA"
     fi
   else 
     printGreen "MAGISK_PREINIT_DEVICE not set for device, not creating magisk OTA"
@@ -199,11 +199,6 @@ function checkBuildNecessary() {
       selectedAsset=$(echo "${response}" | jq -r --arg assetPrefix "${DEVICE_ID}-${OTA_VERSION}" \
         '.assets[] | select(.name | startswith($assetPrefix)) | .name' \
           | grep "${flavor}" || true)
-      # "magisk" is a substring of "magisk-pixin". Without this, an existing magisk-pixin asset
-      # would make the plain magisk flavor be skipped.
-      if [[ "$flavor" == 'magisk' ]]; then
-        selectedAsset=$(echo "${selectedAsset}" | grep -v 'magisk-pixin' || true)
-      fi
   
       if [[ -n "${selectedAsset}" ]] && [[ "$FORCE_BUILD" != 'true' ]] && [[ "$UPLOAD_TEST_OTA" != 'true' ]]; then
         printGreen "Skipping build of asset name '$POTENTIAL_ASSET_NAME'. Because this flavor already is released with a different commit." \
@@ -257,8 +252,8 @@ function downloadAndroidDependencies() {
   fi
 
   # pixincreate's fork releases its APK as "app-release.apk" and uses the same tags as upstream magisk
-  if ! ls ".tmp/magisk-pixin-$MAGISK_VERSION.apk" >/dev/null 2>&1 && [[ "${POTENTIAL_ASSETS['magisk-pixin']+isset}" ]]; then
-    curl --fail -sLo ".tmp/magisk-pixin-$MAGISK_VERSION.apk" "https://github.com/pixincreate/Magisk/releases/download/$MAGISK_VERSION/app-release.apk"
+  if ! ls ".tmp/pixincreate-$MAGISK_VERSION.apk" >/dev/null 2>&1 && [[ "${POTENTIAL_ASSETS['pixincreate']+isset}" ]]; then
+    curl --fail -sLo ".tmp/pixincreate-$MAGISK_VERSION.apk" "https://github.com/pixincreate/Magisk/releases/download/$MAGISK_VERSION/app-release.apk"
   fi
 
   if ! ls ".tmp/$OTA_TARGET.zip" >/dev/null 2>&1; then
@@ -352,8 +347,8 @@ function patchOTAs() {
         args+=("--patch-arg=--magisk" "--patch-arg" ".tmp/magisk-$MAGISK_VERSION.apk")
         args+=("--patch-arg=--magisk-preinit-device" "--patch-arg" "$MAGISK_PREINIT_DEVICE")
       fi
-      if [[ "$flavor" == 'magisk-pixin' ]]; then
-        args+=("--patch-arg=--magisk" "--patch-arg" ".tmp/magisk-pixin-$MAGISK_VERSION.apk")
+      if [[ "$flavor" == 'pixincreate' ]]; then
+        args+=("--patch-arg=--magisk" "--patch-arg" ".tmp/pixincreate-$MAGISK_VERSION.apk")
         args+=("--patch-arg=--magisk-preinit-device" "--patch-arg" "$MAGISK_PREINIT_DEVICE")
       fi
 


### PR DESCRIPTION
Adds pixincreate's magisk fork as an additional `magisk-pixin` flavor, as suggested in #293.

- New `SKIP_MAGISK_PIXIN` var, defaulting to `true`, so the flavor is never silently forced on existing users
- Reuses `MAGISK_VERSION`, since the fork uses the same tags as upstream magisk
- Only built when `MAGISK_PREINIT_DEVICE` is set, like the regular magisk flavor
- Set to `false` on push/PR builds, so the flavor is covered by CI

Note: `"magisk"` is a substring of `"magisk-pixin"`, so the asset lookup in `checkBuildNecessary` needed an explicit exclusion. Without it, an existing magisk-pixin asset makes the plain magisk flavor be skipped.

Tested on my own fork: all three flavors build and patch successfully.