### PR TITLE
Add SKIP_MAGISK env to allow skipping the upstream magisk flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ This variant can be built as an additional `pixincreate` flavor, next to the reg
 It is disabled by default, so it is never silently forced on existing users. Enable it by setting `SKIP_PIXINCREATE=false`
 (or the `skip-pixincreate` input in `release-single.yaml`). It requires `MAGISK_PREINIT_DEVICE` to be set, just like the regular magisk flavor,
 and it reuses `MAGISK_VERSION`, since the fork uses the same tags as upstream magisk.
+If you only want the `pixincreate` flavor, you can additionally set `SKIP_MAGISK=true`.
 
 The resulting OTAs are published as a separate flavor, so in Custota you would point to the `pixincreate` path of your OTA server, e.g.
 `https://rooted-graphene.github.io/ota/pixincreate`. As with the other flavors, you can switch between them via OTA updates.

--- a/rooted-ota.sh
+++ b/rooted-ota.sh
@@ -28,6 +28,8 @@ GITHUB_REPO=${GITHUB_REPO:-''}
 MAGISK_PREINIT_DEVICE=${MAGISK_PREINIT_DEVICE:-}
 # Skip creation of rootless OTA by setting to "true"
 SKIP_ROOTLESS=${SKIP_ROOTLESS:-'false'}
+# Skip creation of magisk OTA by setting to "true".
+SKIP_MAGISK=${SKIP_MAGISK:-'false'}
 # In addition to upstream magisk, an OTA can be patched with pixincreate's magisk fork,
 # which contains patches that make zygisk work on GrapheneOS.
 # https://github.com/pixincreate/Magisk
@@ -147,9 +149,13 @@ function checkBuildNecessary() {
   currentCommit=$(git rev-parse --short HEAD)
   POTENTIAL_ASSETS=()
     
-  if [[ -n "$MAGISK_PREINIT_DEVICE" ]]; then 
-    # e.g. oriole-2023121200-magisk-v26.4-4647f74-dirty.zip
-    POTENTIAL_ASSETS['magisk']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-${MAGISK_VERSION}$(createAssetSuffix).zip"
+  if [[ -n "$MAGISK_PREINIT_DEVICE" ]]; then
+    if [[ "$SKIP_MAGISK" != 'true' ]]; then
+      # e.g. oriole-2023121200-magisk-v26.4-4647f74-dirty.zip
+      POTENTIAL_ASSETS['magisk']="${DEVICE_ID}-${OTA_VERSION}-${currentCommit}-magisk-${MAGISK_VERSION}$(createAssetSuffix).zip"
+    else
+      printGreen "SKIP_MAGISK set, not creating upstream magisk OTA"
+    fi
 
     if [[ "$SKIP_PIXINCREATE" != 'true' ]]; then
       # e.g. oriole-2023121200-pixincreate-v30.7-4647f74-dirty.zip


### PR DESCRIPTION
Since pixincreate magisk support was added, `SKIP_PIXINCREATE=false` enables that flavor in addition to upstream one, but there is no way to build only the pixincreate flavor yet.

Would be useful for anyone (like me) who only wants the pixincreate flavor